### PR TITLE
Setup for evaluating tuning strategies on LLaMA 3.1 8B for Clembench games

### DIFF
--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit (baseline_no_tuning).html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit (baseline_no_tuning).html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-t0.0</th>
+      <td>19.58</td>
+      <td>49.43</td>
+      <td>39.62</td>
+      <td>43.08</td>
+      <td>26.79</td>
+      <td>44.69</td>
+      <td>88.33</td>
+      <td>12.58</td>
+      <td>21.9</td>
+      <td>76.27</td>
+      <td>51.98</td>
+      <td>21.12</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>60.0</td>
+      <td>57.43</td>
+      <td>11.29</td>
+      <td>26.67</td>
+      <td>61.27</td>
+      <td>11.77</td>
+      <td>100.0</td>
+      <td>13.33</td>
+      <td>34.57</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>100.0</td>
+      <td>23.32</td>
+      <td>30.37</td>
+      <td>100.0</td>
+      <td>40.0</td>
+      <td>49.26</td>
+      <td>100.0</td>
+      <td>29.17</td>
+      <td>42.48</td>
+      <td>36.0</td>
+      <td>54.89</td>
+      <td>9.61</td>
+      <td>20.0</td>
+      <td>50.2</td>
+      <td>12.05</td>
+      <td>56.67</td>
+      <td>94.12</td>
+      <td>24.25</td>
+      <td>33.33</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF-augmented.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF-augmented.html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.0</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.3</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.3</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.0</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas.html
@@ -1,0 +1,234 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.00</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.30</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.30</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.00</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-t0.0</th>
+      <td>15.95</td>
+      <td>47.49</td>
+      <td>33.58</td>
+      <td>8.46</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>3.39</td>
+      <td>62.0</td>
+      <td>2.83</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>94.0</td>
+      <td>60.87</td>
+      <td>14.87</td>
+      <td>40.0</td>
+      <td>65.98</td>
+      <td>18.23</td>
+      <td>63.33</td>
+      <td>10.53</td>
+      <td>31.53</td>
+      <td>100.0</td>
+      <td>15.38</td>
+      <td>36.13</td>
+      <td>97.87</td>
+      <td>26.76</td>
+      <td>21.03</td>
+      <td>100.00</td>
+      <td>32.22</td>
+      <td>46.99</td>
+      <td>98.33</td>
+      <td>1.13</td>
+      <td>6.08</td>
+      <td>72.0</td>
+      <td>56.34</td>
+      <td>11.46</td>
+      <td>3.33</td>
+      <td>40.0</td>
+      <td>NaN</td>
+      <td>46.67</td>
+      <td>92.86</td>
+      <td>26.73</td>
+      <td>50.0</td>
+      <td>3.33</td>
+      <td>12.91</td>
+      <td>10.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>20.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-wildchat-lora-t0.0</th>
+      <td>8.44</td>
+      <td>21.77</td>
+      <td>38.76</td>
+      <td>21.54</td>
+      <td>39.29</td>
+      <td>49.73</td>
+      <td>75.0</td>
+      <td>15.56</td>
+      <td>23.14</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>6.0</td>
+      <td>61.11</td>
+      <td>20.53</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>5.26</td>
+      <td>22.94</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>62.00</td>
+      <td>18.89</td>
+      <td>28.88</td>
+      <td>12.22</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>93.33</td>
+      <td>33.63</td>
+      <td>44.78</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>36.67</td>
+      <td>100.00</td>
+      <td>0.00</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-4*4-700-t0.0</th>
+      <td>14.39</td>
+      <td>34.79</td>
+      <td>41.35</td>
+      <td>25.38</td>
+      <td>21.21</td>
+      <td>41.51</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>84.0</td>
+      <td>62.0</td>
+      <td>17.31</td>
+      <td>33.33</td>
+      <td>59.48</td>
+      <td>21.71</td>
+      <td>100.0</td>
+      <td>23.33</td>
+      <td>43.02</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>40.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>100.0</td>
+      <td>36.67</td>
+      <td>48.46</td>
+      <td>60.0</td>
+      <td>19.91</td>
+      <td>36.04</td>
+      <td>2.0</td>
+      <td>60.0</td>
+      <td>NaN</td>
+      <td>6.67</td>
+      <td>38.89</td>
+      <td>7.86</td>
+      <td>40.0</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_wildchat.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_wildchat.html
@@ -1,0 +1,177 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.00</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.30</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.3</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.00</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-wildchat-lora-t0.0</th>
+      <td>8.44</td>
+      <td>21.77</td>
+      <td>38.76</td>
+      <td>21.54</td>
+      <td>39.29</td>
+      <td>49.73</td>
+      <td>75.0</td>
+      <td>15.56</td>
+      <td>23.14</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>6.0</td>
+      <td>61.11</td>
+      <td>20.53</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>5.26</td>
+      <td>22.94</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>62.0</td>
+      <td>18.89</td>
+      <td>28.88</td>
+      <td>12.22</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>93.33</td>
+      <td>33.63</td>
+      <td>44.78</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>36.67</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_pref_mixture.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_pref_mixture.html
@@ -1,0 +1,126 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>matchit_ascii, % Played</th>
+      <th>matchit_ascii, Quality Score</th>
+      <th>matchit_ascii, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-mixture-t0.0</th>
+      <td>0.68</td>
+      <td>4.54</td>
+      <td>15.06</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>1.67</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>23.33</td>
+      <td>14.29</td>
+      <td>37.8</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>30.88</td>
+      <td>46.08</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_wildchat_on_policy_8b.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_dpo_Tulu_wildchat_on_policy_8b.html
@@ -1,0 +1,126 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>matchit_ascii, % Played</th>
+      <th>matchit_ascii, Quality Score</th>
+      <th>matchit_ascii, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-wildchat-reused-on-policy-8b-t0.0</th>
+      <td>13.01</td>
+      <td>31.73</td>
+      <td>41.01</td>
+      <td>26.15</td>
+      <td>26.47</td>
+      <td>44.78</td>
+      <td>91.67</td>
+      <td>12.12</td>
+      <td>20.65</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>58.0</td>
+      <td>57.31</td>
+      <td>12.24</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>93.33</td>
+      <td>17.86</td>
+      <td>39.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>93.75</td>
+      <td>17.19</td>
+      <td>24.79</td>
+      <td>10.0</td>
+      <td>44.44</td>
+      <td>52.7</td>
+      <td>98.33</td>
+      <td>25.71</td>
+      <td>40.27</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>30.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>3.33</td>
+      <td>50.0</td>
+      <td>NaN</td>
+      <td>3.33</td>
+      <td>100.0</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_sft_Tulu_IF_personas.html
+++ b/potsdam_blitz_team/results_html/results_Llama_3.1_8b_it_4bit_sft_Tulu_IF_personas.html
@@ -1,0 +1,177 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-4*4-700-t0.0</th>
+      <td>14.39</td>
+      <td>34.79</td>
+      <td>41.35</td>
+      <td>25.38</td>
+      <td>21.21</td>
+      <td>41.51</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>84.0</td>
+      <td>62.0</td>
+      <td>17.31</td>
+      <td>33.33</td>
+      <td>59.48</td>
+      <td>21.71</td>
+      <td>100.00</td>
+      <td>23.33</td>
+      <td>43.02</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>40.0</td>
+      <td>0.00</td>
+      <td>0.00</td>
+      <td>100.0</td>
+      <td>36.67</td>
+      <td>48.46</td>
+      <td>60.0</td>
+      <td>19.91</td>
+      <td>36.04</td>
+      <td>2.0</td>
+      <td>60.00</td>
+      <td>NaN</td>
+      <td>6.67</td>
+      <td>38.89</td>
+      <td>7.86</td>
+      <td>40.00</td>
+      <td>100.00</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-sft-personas-lora-t0.0</th>
+      <td>13.37</td>
+      <td>47.67</td>
+      <td>28.05</td>
+      <td>42.31</td>
+      <td>27.27</td>
+      <td>44.95</td>
+      <td>76.67</td>
+      <td>24.64</td>
+      <td>37.47</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>96.67</td>
+      <td>20.69</td>
+      <td>41.23</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>82.0</td>
+      <td>15.12</td>
+      <td>20.44</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.40</td>
+      <td>100.0</td>
+      <td>16.67</td>
+      <td>33.19</td>
+      <td>56.0</td>
+      <td>48.55</td>
+      <td>10.33</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>76.67</td>
+      <td>60.87</td>
+      <td>49.9</td>
+      <td>80.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Includes experiment structure for testing the impact of general ability tuning (instruction-following, conversational data, preference mixtures) on interactive task performance. Supports DPO and SFT approaches for instruction and preference tuning. Uses Tulu datasets.